### PR TITLE
feat(lookup): adapta API para busca avançada

### DIFF
--- a/src/heroes/heroes.controller.ts
+++ b/src/heroes/heroes.controller.ts
@@ -24,14 +24,14 @@ export class HeroesController {
   @ApiQuery({name: 'page', required: false})
   @ApiQuery({name: 'pageSize', required: false})
   @ApiQuery({name: 'order', required: false})
+  @ApiQuery({name: 'name', required: false})
+  @ApiQuery({name: 'nickname', required: false})
+  @ApiQuery({name: 'email', required: false})
   @Get()
   async findByFilter(
-    @Query('filter') filter?: string,
-    @Query('page') page?: number,
-    @Query('pageSize') pageSize?: number,
-    @Query('order') order?: string
+    @Query() params?: string
   ): Promise<Array<Hero>> {
-    return this.heroesService.getByFilter(filter, page, pageSize, order);
+    return this.heroesService.getByFilter(params);
   }
 
   @ApiResponse({ status: 200, type: CreateHeroDto })


### PR DESCRIPTION
Adaptação da API para a busca avançada, agora qualquer query param que não seja filter, page, pageSize ou order é considero como busca avançada e fara a busca considerando todos eles, a busca do registro é feito por todos os filtros da busca avançada e utiliza AND para encontrar o registro.

Fixes DTHFUI-487