### PR TITLE
ci(deploy): atualiza buildpack para heroku/buildpacks:24

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -6,7 +6,7 @@ kill_timeout = 5
 processes = []
 
 [build]
-  builder = "heroku/buildpacks:20"
+  builder = "heroku/buildpacks:24"
 
 [env]
   PORT = "8080"


### PR DESCRIPTION
O arquivo fly.toml foi alterado para atualizar o buildpack utilizado na seção [build], passando de heroku/buildpacks:20 para heroku/buildpacks:24.
- Corrige o erro relacionado a remoção do heroku/buildpacks:20: 
![image](https://github.com/user-attachments/assets/29594dd6-5ff2-43dc-b7fe-e3abfee947a5)
