### PR TITLE
feat(employees): adiciona módulo employees com dados mocados e filtro OData

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { CitiesModule } from './cities/cities.module';
 import { HotelsModule } from './hotels/hotels.module';
 import { UploadModule } from './upload/upload.module';
 import { BatchDeleteModule } from './batch-delete/batch-delete.module';
+import { EmployeesModule } from './employees/employees.module';
 
 @Module({
   imports: [
@@ -26,7 +27,8 @@ import { BatchDeleteModule } from './batch-delete/batch-delete.module';
     PeopleModule,
     CitiesModule,
     UploadModule,
-    BatchDeleteModule
+    BatchDeleteModule,
+    EmployeesModule
   ]
 })
 export class AppModule {}

--- a/src/employees/db/employees.data.ts
+++ b/src/employees/db/employees.data.ts
@@ -1,0 +1,84 @@
+import { Employee } from '../interfaces/employee.interface';
+
+export const employees: Array<Employee> = [
+  {
+    id: 1, name: 'Ana Silva', age: 28, city: 'São Paulo',
+    department: 'TI', salary: 8500, status: 'Ativo', hireDate: '2023-03-15'
+  },
+  {
+    id: 2, name: 'Bruno Costa', age: 35, city: 'Rio de Janeiro',
+    department: 'RH', salary: 7200, status: 'Ativo', hireDate: '2022-01-10'
+  },
+  {
+    id: 3, name: 'Carla Mendes', age: 42, city: 'São Paulo',
+    department: 'Financeiro', salary: 12000, status: 'Ativo', hireDate: '2020-06-01'
+  },
+  {
+    id: 4, name: 'Diego Oliveira', age: 31, city: 'Belo Horizonte',
+    department: 'TI', salary: 9800, status: 'Inativo', hireDate: '2021-09-20'
+  },
+  {
+    id: 5, name: 'Elena Santos', age: 26, city: 'Curitiba',
+    department: 'Marketing', salary: 6500, status: 'Ativo', hireDate: '2024-02-01'
+  },
+  {
+    id: 6, name: 'Fernando Lima', age: 39, city: 'São Paulo',
+    department: 'TI', salary: 15000, status: 'Ativo', hireDate: '2019-04-15'
+  },
+  {
+    id: 7, name: 'Gabriela Rocha', age: 33, city: 'Porto Alegre',
+    department: 'RH', salary: 8000, status: 'Inativo', hireDate: '2022-07-01'
+  },
+  {
+    id: 8, name: 'Hugo Pereira', age: 45, city: 'Rio de Janeiro',
+    department: 'Financeiro', salary: 14000, status: 'Ativo', hireDate: '2018-11-10'
+  },
+  {
+    id: 9, name: 'Isabela Alves', age: 29, city: 'São Paulo',
+    department: 'Marketing', salary: 7800, status: 'Ativo', hireDate: '2023-08-20'
+  },
+  {
+    id: 10, name: 'João Ferreira', age: 37, city: 'Brasília',
+    department: 'TI', salary: 11000, status: 'Ativo', hireDate: '2021-01-05'
+  },
+  {
+    id: 11, name: 'Karen Souza', age: 24, city: 'Curitiba',
+    department: 'TI', salary: 6000, status: 'Ativo', hireDate: '2024-06-15'
+  },
+  {
+    id: 12, name: 'Lucas Barbosa', age: 41, city: 'São Paulo',
+    department: 'Financeiro', salary: 13500, status: 'Inativo', hireDate: '2019-02-28'
+  },
+  {
+    id: 13, name: 'Marina Castro', age: 30, city: 'Rio de Janeiro',
+    department: 'Marketing', salary: 8200, status: 'Ativo', hireDate: '2022-12-01'
+  },
+  {
+    id: 14, name: 'Nelson Dias', age: 48, city: 'Belo Horizonte',
+    department: 'RH', salary: 9500, status: 'Ativo', hireDate: '2017-05-10'
+  },
+  {
+    id: 15, name: 'Olivia Ribeiro', age: 27, city: 'Porto Alegre',
+    department: 'TI', salary: 7500, status: 'Ativo', hireDate: '2023-10-01'
+  },
+  {
+    id: 16, name: 'Paulo Cardoso', age: 36, city: 'São Paulo',
+    department: 'TI', salary: 10500, status: 'Inativo', hireDate: '2020-08-15'
+  },
+  {
+    id: 17, name: 'Raquel Martins', age: 32, city: 'Brasília',
+    department: 'Financeiro', salary: 9000, status: 'Ativo', hireDate: '2021-11-20'
+  },
+  {
+    id: 18, name: 'Samuel Teixeira', age: 44, city: 'Rio de Janeiro',
+    department: 'Marketing', salary: 11500, status: 'Ativo', hireDate: '2018-03-01'
+  },
+  {
+    id: 19, name: 'Tatiana Moreira', age: 25, city: 'Curitiba',
+    department: 'RH', salary: 5800, status: 'Ativo', hireDate: '2024-01-15'
+  },
+  {
+    id: 20, name: 'Victor Nascimento', age: 38, city: 'São Paulo',
+    department: 'TI', salary: 12500, status: 'Ativo', hireDate: '2020-04-01'
+  }
+];

--- a/src/employees/dto/create-employee.dto.ts
+++ b/src/employees/dto/create-employee.dto.ts
@@ -1,0 +1,29 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateEmployeeDto {
+
+  @ApiPropertyOptional()
+  id: number;
+
+  @ApiPropertyOptional()
+  name: string;
+
+  @ApiPropertyOptional()
+  age: number;
+
+  @ApiPropertyOptional()
+  city: string;
+
+  @ApiPropertyOptional()
+  department: string;
+
+  @ApiPropertyOptional()
+  salary: number;
+
+  @ApiPropertyOptional()
+  status: string;
+
+  @ApiPropertyOptional()
+  hireDate: string;
+
+}

--- a/src/employees/dto/get-employees.dto.ts
+++ b/src/employees/dto/get-employees.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { CreateEmployeeDto } from './create-employee.dto';
+
+export class GetEmployeesDto {
+
+  @ApiProperty({
+    type: () => [CreateEmployeeDto],
+  })
+  items: Array<CreateEmployeeDto>;
+
+  @ApiProperty()
+  hasNext: boolean;
+
+}

--- a/src/employees/employees.controller.ts
+++ b/src/employees/employees.controller.ts
@@ -1,0 +1,58 @@
+import { Controller, Get, Param, Body, Post, Put, Query, Delete } from '@nestjs/common';
+import { ApiResponse, ApiParam, ApiTags, ApiBody, ApiQuery } from '@nestjs/swagger';
+
+import { EmployeesService } from './employees.service';
+import { CreateEmployeeDto } from './dto/create-employee.dto';
+import { GetEmployeesDto } from './dto/get-employees.dto';
+
+@ApiTags('employees')
+@Controller('employees')
+export class EmployeesController {
+
+  constructor(private employeesService: EmployeesService) {}
+
+  @ApiResponse({ status: 200, type: GetEmployeesDto })
+  @ApiQuery({ name: 'search', required: false })
+  @ApiQuery({ name: '$filter', required: false })
+  @ApiQuery({ name: 'page', required: false })
+  @ApiQuery({ name: 'pageSize', required: false })
+  @Get()
+  getEmployees(@Query() query) {
+    const search = query['search'];
+    const filter = query['$filter'];
+    const page = query['page'];
+    const pageSize = query['pageSize'];
+
+    return this.employeesService.getEmployees(search, filter, page, pageSize);
+  }
+
+  @ApiResponse({ status: 200, type: CreateEmployeeDto })
+  @ApiParam({ name: 'id' })
+  @Get(':id')
+  getEmployee(@Param('id') id: string) {
+    return this.employeesService.getEmployee(parseInt(id, 10));
+  }
+
+  @ApiResponse({ status: 201, type: CreateEmployeeDto })
+  @ApiBody({ type: CreateEmployeeDto })
+  @Post()
+  save(@Body() employee: CreateEmployeeDto) {
+    this.employeesService.save(employee);
+  }
+
+  @ApiResponse({ status: 200, type: CreateEmployeeDto })
+  @ApiParam({ name: 'id' })
+  @ApiBody({ type: CreateEmployeeDto })
+  @Put(':id')
+  update(@Body() employee: CreateEmployeeDto, @Param('id') id: string) {
+    this.employeesService.update(parseInt(id, 10), employee);
+  }
+
+  @ApiResponse({ status: 200 })
+  @ApiParam({ name: 'id' })
+  @Delete(':id')
+  deleteEmployee(@Param('id') id: string) {
+    return this.employeesService.delete(parseInt(id, 10));
+  }
+
+}

--- a/src/employees/employees.module.ts
+++ b/src/employees/employees.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+
+import { EmployeesController } from './employees.controller';
+import { EmployeesService } from './employees.service';
+
+@Module({
+  controllers: [EmployeesController],
+  providers: [EmployeesService]
+})
+export class EmployeesModule {}

--- a/src/employees/employees.service.ts
+++ b/src/employees/employees.service.ts
@@ -1,0 +1,145 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+import { employees } from './db/employees.data';
+import { Employee } from './interfaces/employee.interface';
+import { Utils } from 'src/utils/utils';
+
+@Injectable()
+export class EmployeesService {
+
+  employees = [...employees];
+
+  getEmployees(search?: string, filter?: string, page?: string, pageSize?: string): { items: Array<Employee>, hasNext: boolean } {
+    let filteredEmployees = this.employees;
+
+    if (filter) {
+      filteredEmployees = this.applyODataFilter(filteredEmployees, filter);
+    } else if (search) {
+      filteredEmployees = Utils.filterByAll(search, filteredEmployees);
+    }
+
+    const total = filteredEmployees.length;
+    const parsedPage = page ? parseInt(page, 10) : undefined;
+    const parsedPageSize = pageSize ? parseInt(pageSize, 10) : undefined;
+    filteredEmployees = this.paginate(filteredEmployees, parsedPage, parsedPageSize);
+
+    return {
+      items: filteredEmployees,
+      hasNext: parsedPageSize ? total > (parsedPageSize * (parsedPage || 1)) : false
+    };
+  }
+
+  getEmployee(id: number): Employee {
+    const employee = this.employees.find(e => e.id === id);
+
+    if (!employee) {
+      throw new NotFoundException(`Funcionário ${id} não encontrado!`);
+    }
+
+    return employee;
+  }
+
+  save(employee: Employee) {
+    const id = this.employees.length > 0 ? Math.max(...this.employees.map(e => e.id)) + 1 : 1;
+    this.employees.push({ ...employee, id });
+  }
+
+  update(id: number, updatedEmployee: Employee) {
+    const employee = this.getEmployee(id);
+    Object.assign(employee, updatedEmployee);
+  }
+
+  delete(id: number) {
+    const index = this.employees.findIndex(e => e.id === id);
+
+    if (index === -1) {
+      throw new NotFoundException(`Funcionário ${id} não encontrado!`);
+    }
+
+    this.employees.splice(index, 1);
+    return { message: 'Funcionário removido com sucesso' };
+  }
+
+  private paginate(filteredEmployees: Array<Employee>, page?: number, pageSize?: number) {
+    if (pageSize || page) {
+      return Utils.paginate(filteredEmployees, page, pageSize);
+    }
+
+    return filteredEmployees;
+  }
+
+  private applyODataFilter(items: Array<Employee>, filter: string): Array<Employee> {
+    const conditions = filter.split(/\s+and\s+/i);
+
+    return items.filter(item => {
+      return conditions.every(condition => this.evaluateCondition(item, condition.trim()));
+    });
+  }
+
+  private evaluateCondition(item: any, condition: string): boolean {
+    // contains(property, 'value')
+    const containsMatch = condition.match(/contains\((\w+),\s*'([^']+)'\)/i);
+    if (containsMatch) {
+      const value = String(item[containsMatch[1]] || '').toLowerCase();
+      return value.includes(containsMatch[2].toLowerCase());
+    }
+
+    // startswith(property, 'value')
+    const startsWithMatch = condition.match(/startswith\((\w+),\s*'([^']+)'\)/i);
+    if (startsWithMatch) {
+      const value = String(item[startsWithMatch[1]] || '').toLowerCase();
+      return value.startsWith(startsWithMatch[2].toLowerCase());
+    }
+
+    // endswith(property, 'value')
+    const endsWithMatch = condition.match(/endswith\((\w+),\s*'([^']+)'\)/i);
+    if (endsWithMatch) {
+      const value = String(item[endsWithMatch[1]] || '').toLowerCase();
+      return value.endsWith(endsWithMatch[2].toLowerCase());
+    }
+
+    // property op 'string_value'
+    const stringMatch = condition.match(/(\w+)\s+(eq|ne)\s+'([^']+)'/);
+    if (stringMatch) {
+      const value = String(item[stringMatch[1]] || '');
+      const compareValue = stringMatch[3];
+      if (stringMatch[2] === 'eq') {
+        return value.toLowerCase() === compareValue.toLowerCase();
+      }
+      return value.toLowerCase() !== compareValue.toLowerCase();
+    }
+
+    // property op date_value (YYYY-MM-DD)
+    const dateMatch = condition.match(/(\w+)\s+(eq|ne|gt|ge|lt|le)\s+(\d{4}-\d{2}-\d{2})/);
+    if (dateMatch) {
+      const value = new Date(item[dateMatch[1]]).getTime();
+      const compareValue = new Date(dateMatch[3]).getTime();
+      switch (dateMatch[2]) {
+        case 'eq': return value === compareValue;
+        case 'ne': return value !== compareValue;
+        case 'gt': return value > compareValue;
+        case 'ge': return value >= compareValue;
+        case 'lt': return value < compareValue;
+        case 'le': return value <= compareValue;
+      }
+    }
+
+    // property op number_value
+    const numberMatch = condition.match(/(\w+)\s+(eq|ne|gt|ge|lt|le)\s+(\d+(?:\.\d+)?)/);
+    if (numberMatch) {
+      const value = Number(item[numberMatch[1]]);
+      const compareValue = Number(numberMatch[3]);
+      switch (numberMatch[2]) {
+        case 'eq': return value === compareValue;
+        case 'ne': return value !== compareValue;
+        case 'gt': return value > compareValue;
+        case 'ge': return value >= compareValue;
+        case 'lt': return value < compareValue;
+        case 'le': return value <= compareValue;
+      }
+    }
+
+    return true;
+  }
+
+}

--- a/src/employees/interfaces/employee.interface.ts
+++ b/src/employees/interfaces/employee.interface.ts
@@ -1,0 +1,19 @@
+export interface Employee {
+
+  id?: number;
+
+  name?: string;
+
+  age?: number;
+
+  city?: string;
+
+  department?: string;
+
+  salary?: number;
+
+  status?: string;
+
+  hireDate?: string;
+
+}


### PR DESCRIPTION
## Summary

Adiciona o módulo `employees` ao po-sample-api, servindo 20 registros mocados de funcionários com suporte a filtro OData via `$filter` query param. Este endpoint será consumido pela POC de AI Search no po-angular (`po-table`).

**Estrutura do módulo** segue o padrão dos módulos existentes (people, heroes):
- `employees.controller.ts` — CRUD completo (GET lista, GET por id, POST, PUT, DELETE)
- `employees.service.ts` — lógica de dados, paginação e parser de filtro OData
- `employees.data.ts` — 20 funcionários mocados (in-memory)
- `employee.interface.ts` / DTOs — tipagem e documentação Swagger

**Operadores OData suportados no `$filter`:**
- Funções: `contains()`, `startswith()`, `endswith()`
- Comparação string: `eq`, `ne`
- Comparação numérica/data: `eq`, `ne`, `gt`, `ge`, `lt`, `le`
- Conjunção: `and`

Exemplos: `$filter=age gt 30`, `$filter=contains(name,'Silva') and status eq 'Ativo'`, `$filter=hireDate ge 2024-01-01`

## Updates since last revision

- **Fix:** Corrigida a ordem do object spread no método `save()` — de `{ id, ...employee }` para `{ ...employee, id }` — garantindo que o ID auto-gerado sempre prevaleça sobre um eventual `id` enviado no body da requisição.
- **Fix:** Corrigido `parseInt(undefined, 10)` que retornava `NaN` na paginação — agora faz parse condicional (`page ? parseInt(page, 10) : undefined`) para que `Utils.paginate` receba `undefined` e aplique seus defaults corretamente. Também corrigido o cálculo de `hasNext` para usar `parsedPage || 1` como fallback.

## Review & Testing Checklist for Human

- [ ] **Validar o parser OData** (`evaluateCondition` em `employees.service.ts`): condições não reconhecidas retornam `true` silenciosamente (linha ~143) — verificar se este comportamento é aceitável ou se deveria rejeitar/ignorar o registro
- [ ] **Operador `or` NÃO é suportado** — apenas `and`. Confirmar se isso é suficiente para os cenários da POC
- [ ] **`CreateEmployeeDto` ainda declara campo `id`** — embora o spread fix garanta que seja ignorado no `save()`, o Swagger sugere que o client pode enviar `id`. Considerar remover `id` do DTO de criação se não for desejado
- [ ] **Testar localmente** com `PORT=3001 npm run start` e executar:
  - `GET /v1/employees` — deve retornar 20 items
  - `GET /v1/employees?pageSize=5` — deve retornar 5 items com `hasNext: true` (valida fix de paginação)
  - `GET /v1/employees?$filter=department eq 'TI' and age gt 30` — deve filtrar corretamente
  - `GET /v1/employees?$filter=contains(name,'Silva')` — deve retornar Ana Silva
  - `POST /v1/employees` com body contendo `id` — verificar que o id auto-gerado prevalece
  - Verificar Swagger em `/api`

### Notes
- Dados são in-memory e resetam ao reiniciar o servidor (comportamento esperado para sample API)
- O import `import { Utils } from 'src/utils/utils'` usa path absoluto — consistente com o padrão do projeto
- Não inclui testes unitários (nenhum módulo existente no repo os possui)

Link to Devin session: https://totvs.devinenterprise.com/sessions/b2b0144d884046c9ac956df7b6e1a116
Requested by: @alinelariguet
<!-- devin-review-badge-begin -->

---

<a href="https://totvs.devinenterprise.com/review/po-ui/po-sample-api/pull/43" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
